### PR TITLE
fix: Handle EOF

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -13,6 +13,7 @@ func handleGet(m *MiniMemcached, cmdLine []string, conn net.Conn) {
 		return
 	}
 	key := cmdLine[2]
+
 	m.gets([]string{key}, conn)
 }
 
@@ -23,6 +24,7 @@ func handleGets(m *MiniMemcached, cmdLine []string, conn net.Conn) {
 		return
 	}
 	cmdLine[len(cmdLine)-1] = strings.TrimSuffix(cmdLine[len(cmdLine)-1], string(crlf))
+
 	m.gets(cmdLine[1:], conn)
 }
 
@@ -33,27 +35,32 @@ func handleSet(m *MiniMemcached, cmdLine []string, value []byte, conn net.Conn) 
 		return
 	}
 	key := cmdLine[1]
+
 	flags, err := strconv.ParseUint(cmdLine[2], 0, 32)
 	if err != nil {
 		_, _ = conn.Write(resultErr)
 		return
 	}
+
 	expiration, err := strconv.ParseInt(cmdLine[3], 0, 32)
 	if err != nil {
 		_, _ = conn.Write(resultErr)
 		return
 	}
+
 	bytes, err := strconv.Atoi(cmdLine[4])
 	if err != nil {
 		_, _ = conn.Write(resultErr)
 		return
 	}
+
 	item := &Item{
 		Flags:      uint32(flags),
 		Value:      value,
 		Expiration: int32(expiration),
 		createdAt:  m.clock.Now().Unix(),
 	}
+
 	m.set(key, item, bytes, conn)
 }
 
@@ -63,16 +70,19 @@ func handleAdd(m *MiniMemcached, cmdLine []string, value []byte, conn net.Conn) 
 		return
 	}
 	key := cmdLine[1]
+
 	flags, err := strconv.ParseUint(cmdLine[2], 0, 32)
 	if err != nil {
 		_, _ = conn.Write(resultErr)
 		return
 	}
+
 	expiration, err := strconv.ParseInt(cmdLine[3], 0, 32)
 	if err != nil {
 		_, _ = conn.Write(resultErr)
 		return
 	}
+
 	bytes, err := strconv.Atoi(cmdLine[4])
 	if err != nil {
 		_, _ = conn.Write(resultErr)
@@ -95,18 +105,20 @@ func handleReplace(m *MiniMemcached, cmdLine []string, value []byte, conn net.Co
 		_, _ = conn.Write(resultErr)
 		return
 	}
-
 	key := cmdLine[1]
+
 	flags, err := strconv.ParseUint(cmdLine[2], 0, 32)
 	if err != nil {
 		_, _ = conn.Write(resultErr)
 		return
 	}
+
 	expiration, err := strconv.ParseInt(cmdLine[3], 0, 32)
 	if err != nil {
 		_, _ = conn.Write(resultErr)
 		return
 	}
+
 	bytes, err := strconv.Atoi(cmdLine[4])
 	if err != nil {
 		_, _ = conn.Write(resultErr)
@@ -148,6 +160,7 @@ func handlePrepend(m *MiniMemcached, cmdLine []string, value []byte, conn net.Co
 	}
 
 	key := cmdLine[1]
+
 	bytes, err := strconv.Atoi(cmdLine[4])
 	if err != nil {
 		_, _ = conn.Write(resultErr)
@@ -214,6 +227,7 @@ func handleTouch(m *MiniMemcached, cmdLine []string, conn net.Conn) {
 
 	key := cmdLine[1]
 	expTime := cmdLine[2]
+
 	expiration, err := strconv.ParseInt(expTime, 10, 32)
 	if err != nil {
 		_, _ = conn.Write(resultClientErrInvalidExpTimeArg)
@@ -231,16 +245,19 @@ func handleCas(m *MiniMemcached, cmdLine []string, value []byte, conn net.Conn) 
 	}
 
 	key := cmdLine[1]
+
 	flags, err := strconv.ParseUint(cmdLine[2], 0, 32)
 	if err != nil {
 		_, _ = conn.Write(resultErr)
 		return
 	}
+
 	expiration, err := strconv.ParseInt(cmdLine[3], 0, 32)
 	if err != nil {
 		_, _ = conn.Write(resultErr)
 		return
 	}
+
 	bytes, err := strconv.Atoi(cmdLine[4])
 	if err != nil {
 		_, _ = conn.Write(resultErr)

--- a/minimemcached.go
+++ b/minimemcached.go
@@ -51,10 +51,10 @@ type Item struct {
 	createdAt int64
 }
 
-type MiniMemcachedOption func(m *MiniMemcached)
+type Option func(m *MiniMemcached)
 
 // newMiniMemcached returns a newMiniMemcached, non-started, MiniMemcached object.
-func newMiniMemcached(opts ...MiniMemcachedOption) *MiniMemcached {
+func newMiniMemcached(opts ...Option) *MiniMemcached {
 	m := MiniMemcached{
 		items:    map[string]*Item{},
 		CASToken: 0,
@@ -69,7 +69,7 @@ func newMiniMemcached(opts ...MiniMemcachedOption) *MiniMemcached {
 }
 
 // WithClock applies custom Clock interface. Clock will be used when Item is created
-func WithClock(clk clock.Clock) MiniMemcachedOption {
+func WithClock(clk clock.Clock) Option {
 	return func(m *MiniMemcached) {
 		m.clock = clk
 	}
@@ -77,7 +77,7 @@ func WithClock(clk clock.Clock) MiniMemcachedOption {
 
 // Run creates and starts a MiniMemcached server on a random, available port.
 // Close with Close().
-func Run(cfg *Config, opts ...MiniMemcachedOption) (*MiniMemcached, error) {
+func Run(cfg *Config, opts ...Option) (*MiniMemcached, error) {
 	m := newMiniMemcached(opts...)
 	return m, m.start(cfg.Port)
 }

--- a/minimemcached.go
+++ b/minimemcached.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	Version = "1.0.0"
+	Version = "1.0.1"
 )
 
 type MiniMemcached struct {

--- a/minimemcached.go
+++ b/minimemcached.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	gobytes "bytes"
 	"errors"
+	"io"
 	"net"
 	"strings"
 	"sync"
@@ -133,6 +134,10 @@ func (m *MiniMemcached) serveConn(conn net.Conn) {
 	for {
 		reader := bufio.NewReader(conn)
 		req, err := reader.ReadString('\n')
+		if errors.Is(err, io.EOF) {
+			continue
+		}
+
 		if err != nil {
 			log.Err(err).Msgf("err reading string: %v", err)
 			return

--- a/minimemcached.go
+++ b/minimemcached.go
@@ -85,11 +85,11 @@ func Run(cfg *Config, opts ...Option) (*MiniMemcached, error) {
 
 // Close closes mini-memcached server and clears all objects stored.
 func (m *MiniMemcached) Close() {
-	log.Info().Msg("closed mini-memcached.")
 	m.mu.Lock()
 	m.items = nil
 	m.server.close()
 	m.mu.Unlock()
+	log.Info().Msg("closed mini-memcached.")
 }
 
 func (m *MiniMemcached) Port() uint16 {
@@ -135,14 +135,13 @@ func (m *MiniMemcached) serveConn(conn net.Conn) {
 		reader := bufio.NewReader(conn)
 		req, err := reader.ReadString('\n')
 		if errors.Is(err, io.EOF) {
-			continue
+			break
 		}
 
 		if err != nil {
 			log.Err(err).Msgf("err reading string: %v", err)
 			return
 		}
-
 		req = strings.TrimSuffix(req, "\r\n")
 		cmdLine := strings.Split(req, " ")
 		cmd := strings.ToLower(cmdLine[0])

--- a/minimemcached_test.go
+++ b/minimemcached_test.go
@@ -657,8 +657,8 @@ func TestPrependFail(t *testing.T) {
 
 	mc := memcache.New(fmt.Sprintf(":%d", m.Port()))
 
-	if err := writeAppend(m.Port(), key, []byte(value)); err != nil && !errors.Is(err, memcache.ErrCacheMiss) {
-		t.Errorf("failed to append. err: %v", err)
+	if err := writePrepend(m.Port(), key, []byte(value)); err != nil && !errors.Is(err, memcache.ErrCacheMiss) {
+		t.Errorf("failed to prepend. err: %v", err)
 		return
 	}
 

--- a/server.go
+++ b/server.go
@@ -4,10 +4,12 @@ import (
 	"fmt"
 	"log"
 	"net"
+	"sync"
 )
 
 type Server struct {
-	l net.Listener
+	l  net.Listener
+	mu sync.Mutex
 }
 
 // NewServer starts and returns a server listening on a given port.
@@ -22,8 +24,10 @@ func newServer(port uint16) (*Server, error) {
 
 // Close closes a server started with NewServer().
 func (s *Server) close() {
+	s.mu.Lock()
 	if s.l != nil {
 		_ = s.l.Close()
 		s.l = nil
 	}
+	s.mu.Unlock()
 }

--- a/server.go
+++ b/server.go
@@ -4,12 +4,10 @@ import (
 	"fmt"
 	"log"
 	"net"
-	"sync"
 )
 
 type Server struct {
-	l  net.Listener
-	mu sync.Mutex
+	l net.Listener
 }
 
 // NewServer starts and returns a server listening on a given port.
@@ -24,10 +22,8 @@ func newServer(port uint16) (*Server, error) {
 
 // Close closes a server started with NewServer().
 func (s *Server) close() {
-	s.mu.Lock()
 	if s.l != nil {
 		_ = s.l.Close()
 		s.l = nil
 	}
-	s.mu.Unlock()
 }


### PR DESCRIPTION
As mentioned in the documentation of `ReadString()`, `ReadString()` might return `io.EOF` error when client has closed the connection.

> ReadString Documencation: ReadString reads until the first occurrence of delim in the input, returning a string containing the data up to and including the delimiter. If ReadString encounters an error before finding a delimiter, it returns the data read before the error and the error itself (often io.EOF). ReadString returns err != nil if and only if the returned data does not end in delim. For simple uses, a Scanner may be more convenient.

So I added an if clause to break infinite loop for serving connection if EOF occurs.
+ fixed some wrong test code formats and content.