### PR TITLE
refactor: Unexport unnecessary structs, fields

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -45,8 +45,8 @@ func (m *MiniMemcached) set(key string, item *item, bytes int, conn net.Conn) {
 	m.invalidate(key)
 
 	m.mu.Lock()
-	m.CASToken += 1
-	item.casToken = m.CASToken
+	m.casToken += 1
+	item.casToken = m.casToken
 	m.items[key] = item
 	m.mu.Unlock()
 	_, _ = conn.Write(resultStored)
@@ -72,8 +72,8 @@ func (m *MiniMemcached) add(key string, item *item, bytes int, conn net.Conn) {
 		return
 	}
 
-	m.CASToken += 1
-	item.casToken = m.CASToken
+	m.casToken += 1
+	item.casToken = m.casToken
 	m.items[key] = item
 	_, _ = conn.Write(resultStored)
 }
@@ -97,8 +97,8 @@ func (m *MiniMemcached) replace(key string, item *item, bytes int, conn net.Conn
 		_, _ = conn.Write(resultNotStored)
 		return
 	}
-	m.CASToken += 1
-	item.casToken = m.CASToken
+	m.casToken += 1
+	item.casToken = m.casToken
 	m.items[key] = item
 	_, _ = conn.Write(resultStored)
 }
@@ -123,8 +123,8 @@ func (m *MiniMemcached) append(key string, bytes int, value []byte, conn net.Con
 		_, _ = conn.Write(resultNotStored)
 		return
 	}
-	m.CASToken += 1
-	prevItem.casToken = m.CASToken
+	m.casToken += 1
+	prevItem.casToken = m.casToken
 	prevItem.value = append(prevItem.value, value...)
 	_, _ = conn.Write(resultStored)
 }
@@ -149,8 +149,8 @@ func (m *MiniMemcached) prepend(key string, bytes int, value []byte, conn net.Co
 		_, _ = conn.Write(resultNotStored)
 		return
 	}
-	m.CASToken += 1
-	prevItem.casToken = m.CASToken
+	m.casToken += 1
+	prevItem.casToken = m.casToken
 	prevItem.value = append(value, prevItem.value...)
 	_, _ = conn.Write(resultStored)
 }
@@ -197,8 +197,8 @@ func (m *MiniMemcached) incr(key string, incrValue uint64, conn net.Conn) {
 		return
 	}
 
-	m.CASToken += 1
-	item.casToken = m.CASToken
+	m.casToken += 1
+	item.casToken = m.casToken
 
 	var (
 		numericItemValueInt big.Int
@@ -245,8 +245,8 @@ func (m *MiniMemcached) decr(key string, decrValue uint64, conn net.Conn) {
 		_, _ = conn.Write(resultClientErrIncrDecrNonNumericValue)
 		return
 	}
-	m.CASToken += 1
-	item.casToken = m.CASToken
+	m.casToken += 1
+	item.casToken = m.casToken
 	var decrementedValue uint64
 	if numericItemValue < decrValue {
 		decrementedValue = 0
@@ -283,7 +283,7 @@ func (m *MiniMemcached) touch(key string, expiration int32, conn net.Conn) {
 func (m *MiniMemcached) flushAll(conn net.Conn) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	m.CASToken += 1
+	m.casToken += 1
 	m.items = map[string]*item{}
 	_, _ = conn.Write(resultOK)
 }
@@ -312,8 +312,8 @@ func (m *MiniMemcached) cas(key string, item *item, bytes int, casToken uint64, 
 		_, _ = conn.Write(resultExists)
 		return
 	}
-	m.CASToken += 1
-	item.casToken = m.CASToken
+	m.casToken += 1
+	item.casToken = m.casToken
 	m.items[key] = item
 	_, _ = conn.Write(resultStored)
 }

--- a/commands.go
+++ b/commands.go
@@ -32,7 +32,7 @@ func (m *MiniMemcached) gets(keys []string, conn net.Conn) {
 }
 
 // set() handles memcached `set` command.
-func (m *MiniMemcached) set(key string, item *Item, bytes int, conn net.Conn) {
+func (m *MiniMemcached) set(key string, item *item, bytes int, conn net.Conn) {
 	if !isLegalKey(key) {
 		_, _ = conn.Write(resultClientErrBadCliFormat)
 		return
@@ -53,7 +53,7 @@ func (m *MiniMemcached) set(key string, item *Item, bytes int, conn net.Conn) {
 }
 
 // add() handles memcached `add` command.
-func (m *MiniMemcached) add(key string, item *Item, bytes int, conn net.Conn) {
+func (m *MiniMemcached) add(key string, item *item, bytes int, conn net.Conn) {
 	if !isLegalKey(key) {
 		_, _ = conn.Write(resultClientErrBadCliFormat)
 		return
@@ -79,7 +79,7 @@ func (m *MiniMemcached) add(key string, item *Item, bytes int, conn net.Conn) {
 }
 
 // replace() handles memcached `replace` command.
-func (m *MiniMemcached) replace(key string, item *Item, bytes int, conn net.Conn) {
+func (m *MiniMemcached) replace(key string, item *item, bytes int, conn net.Conn) {
 	if !isLegalKey(key) {
 		_, _ = conn.Write(resultClientErrBadCliFormat)
 		return
@@ -284,12 +284,12 @@ func (m *MiniMemcached) flushAll(conn net.Conn) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.CASToken += 1
-	m.items = map[string]*Item{}
+	m.items = map[string]*item{}
 	_, _ = conn.Write(resultOK)
 }
 
 // cas() handles memcached `cas` command.
-func (m *MiniMemcached) cas(key string, item *Item, bytes int, casToken uint64, conn net.Conn) {
+func (m *MiniMemcached) cas(key string, item *item, bytes int, casToken uint64, conn net.Conn) {
 	if !isLegalKey(key) {
 		_, _ = conn.Write(resultClientErrBadCliFormat)
 		return

--- a/constants.go
+++ b/constants.go
@@ -3,20 +3,20 @@ package minimemcached
 import "fmt"
 
 const (
-	GET       = "get"
-	GETS      = "gets"
-	CAS       = "cas"
-	SET       = "set"
-	TOUCH     = "touch"
-	ADD       = "add"
-	REPLACE   = "replace"
-	APPEND    = "append"
-	PREPEND   = "prepend"
-	DELETE    = "delete"
-	INCR      = "incr"
-	DECR      = "decr"
-	FLUSH_ALL = "flush_all"
-	VERSION   = "version"
+	getCmd      = "get"
+	getsCmd     = "gets"
+	casCmd      = "cas"
+	setCmd      = "set"
+	touchCmd    = "touch"
+	addCmd      = "add"
+	replaceCmd  = "replace"
+	appendCmd   = "append"
+	prependCmd  = "prepend"
+	deleteCmd   = "delete"
+	incrCmd     = "incr"
+	decrCmd     = "decr"
+	flushAllCmd = "flush_all"
+	versionCmd  = "version"
 )
 
 var (
@@ -35,7 +35,6 @@ var (
 	resultClientErrInvalidExpTimeArg       = []byte("CLIENT_ERROR invalid exptime argument\r\n")
 	resultEnd                              = []byte("END\r\n")
 	resultErr                              = []byte("ERROR\r\n")
-	resultNotImplementedCmdErr             = []byte("SERVER_ERROR command yet not implemented in mini-memcached.\r\n")
 	resultVersion                          = []byte(fmt.Sprintf("VERSION mini-memcached %s\r\n", Version))
 	value                                  = "VALUE"
 )

--- a/handlers.go
+++ b/handlers.go
@@ -54,7 +54,7 @@ func handleSet(m *MiniMemcached, cmdLine []string, value []byte, conn net.Conn) 
 		return
 	}
 
-	item := &Item{
+	item := &item{
 		Flags:      uint32(flags),
 		Value:      value,
 		Expiration: int32(expiration),
@@ -90,7 +90,7 @@ func handleAdd(m *MiniMemcached, cmdLine []string, value []byte, conn net.Conn) 
 		return
 	}
 
-	item := &Item{
+	item := &item{
 		Flags:      uint32(flags),
 		Value:      value,
 		Expiration: int32(expiration),
@@ -126,7 +126,7 @@ func handleReplace(m *MiniMemcached, cmdLine []string, value []byte, conn net.Co
 		return
 	}
 
-	item := &Item{
+	item := &item{
 		Flags:      uint32(flags),
 		Value:      value,
 		Expiration: int32(expiration),
@@ -271,7 +271,7 @@ func handleCas(m *MiniMemcached, cmdLine []string, value []byte, conn net.Conn) 
 		return
 	}
 
-	item := &Item{
+	item := &item{
 		Flags:      uint32(flags),
 		Value:      value,
 		Expiration: int32(expiration),

--- a/handlers.go
+++ b/handlers.go
@@ -64,6 +64,7 @@ func handleSet(m *MiniMemcached, cmdLine []string, value []byte, conn net.Conn) 
 	m.set(key, item, bytes, conn)
 }
 
+// handleAdd() handles `add` request.
 func handleAdd(m *MiniMemcached, cmdLine []string, value []byte, conn net.Conn) {
 	if len(cmdLine) != 5 {
 		_, _ = conn.Write(resultErr)
@@ -152,7 +153,7 @@ func handleAppend(m *MiniMemcached, cmdLine []string, value []byte, conn net.Con
 	m.append(key, bytes, value, conn)
 }
 
-// handlePrepend() handles `append` requests.
+// handlePrepend() handles `prepend` requests.
 func handlePrepend(m *MiniMemcached, cmdLine []string, value []byte, conn net.Conn) {
 	if len(cmdLine) != 5 {
 		_, _ = conn.Write(resultErr)

--- a/handlers.go
+++ b/handlers.go
@@ -55,9 +55,9 @@ func handleSet(m *MiniMemcached, cmdLine []string, value []byte, conn net.Conn) 
 	}
 
 	item := &item{
-		Flags:      uint32(flags),
-		Value:      value,
-		Expiration: int32(expiration),
+		flags:      uint32(flags),
+		value:      value,
+		expiration: int32(expiration),
 		createdAt:  m.clock.Now().Unix(),
 	}
 
@@ -91,9 +91,9 @@ func handleAdd(m *MiniMemcached, cmdLine []string, value []byte, conn net.Conn) 
 	}
 
 	item := &item{
-		Flags:      uint32(flags),
-		Value:      value,
-		Expiration: int32(expiration),
+		flags:      uint32(flags),
+		value:      value,
+		expiration: int32(expiration),
 		createdAt:  m.clock.Now().Unix(),
 	}
 
@@ -127,9 +127,9 @@ func handleReplace(m *MiniMemcached, cmdLine []string, value []byte, conn net.Co
 	}
 
 	item := &item{
-		Flags:      uint32(flags),
-		Value:      value,
-		Expiration: int32(expiration),
+		flags:      uint32(flags),
+		value:      value,
+		expiration: int32(expiration),
 		createdAt:  m.clock.Now().Unix(),
 	}
 
@@ -272,9 +272,9 @@ func handleCas(m *MiniMemcached, cmdLine []string, value []byte, conn net.Conn) 
 	}
 
 	item := &item{
-		Flags:      uint32(flags),
-		Value:      value,
-		Expiration: int32(expiration),
+		flags:      uint32(flags),
+		value:      value,
+		expiration: int32(expiration),
 		createdAt:  m.clock.Now().Unix(),
 	}
 

--- a/minimemcached.go
+++ b/minimemcached.go
@@ -146,11 +146,11 @@ func (m *MiniMemcached) serveConn(conn net.Conn) {
 		cmdLine := strings.Split(req, " ")
 		cmd := strings.ToLower(cmdLine[0])
 		switch cmd {
-		case GET:
+		case getCmd:
 			handleGet(m, cmdLine, conn)
-		case GETS:
+		case getsCmd:
 			handleGets(m, cmdLine, conn)
-		case SET:
+		case setCmd:
 			value, err := reader.ReadBytes('\n')
 			if err != nil {
 				handleErr(conn)
@@ -158,7 +158,7 @@ func (m *MiniMemcached) serveConn(conn net.Conn) {
 
 			value = gobytes.TrimSuffix(value, crlf)
 			handleSet(m, cmdLine, value, conn)
-		case ADD:
+		case addCmd:
 			value, err := reader.ReadBytes('\n')
 			if err != nil {
 				handleErr(conn)
@@ -166,7 +166,7 @@ func (m *MiniMemcached) serveConn(conn net.Conn) {
 
 			value = gobytes.TrimSuffix(value, crlf)
 			handleAdd(m, cmdLine, value, conn)
-		case REPLACE:
+		case replaceCmd:
 			value, err := reader.ReadBytes('\n')
 			if err != nil {
 				handleErr(conn)
@@ -174,7 +174,7 @@ func (m *MiniMemcached) serveConn(conn net.Conn) {
 
 			value = gobytes.TrimSuffix(value, crlf)
 			handleReplace(m, cmdLine, value, conn)
-		case APPEND:
+		case appendCmd:
 			value, err := reader.ReadBytes('\n')
 			if err != nil {
 				handleErr(conn)
@@ -182,7 +182,7 @@ func (m *MiniMemcached) serveConn(conn net.Conn) {
 
 			value = gobytes.TrimSuffix(value, crlf)
 			handleAppend(m, cmdLine, value, conn)
-		case PREPEND:
+		case prependCmd:
 			value, err := reader.ReadBytes('\n')
 			if err != nil {
 				handleErr(conn)
@@ -190,17 +190,17 @@ func (m *MiniMemcached) serveConn(conn net.Conn) {
 
 			value = gobytes.TrimSuffix(value, crlf)
 			handlePrepend(m, cmdLine, value, conn)
-		case DELETE:
+		case deleteCmd:
 			handleDelete(m, cmdLine, conn)
-		case INCR:
+		case incrCmd:
 			handleIncr(m, cmdLine, conn)
-		case DECR:
+		case decrCmd:
 			handleDecr(m, cmdLine, conn)
-		case TOUCH:
+		case touchCmd:
 			handleTouch(m, cmdLine, conn)
-		case FLUSH_ALL:
+		case flushAllCmd:
 			handleFlushAll(m, conn)
-		case CAS:
+		case casCmd:
 			value, err := reader.ReadBytes('\n')
 			if err != nil {
 				handleErr(conn)
@@ -208,7 +208,7 @@ func (m *MiniMemcached) serveConn(conn net.Conn) {
 
 			value = gobytes.TrimSuffix(value, crlf)
 			handleCas(m, cmdLine, value, conn)
-		case VERSION:
+		case versionCmd:
 			handleVersion(m, conn)
 		default:
 			handleErr(conn)

--- a/minimemcached.go
+++ b/minimemcached.go
@@ -21,7 +21,7 @@ type MiniMemcached struct {
 	*server
 	mu       sync.RWMutex
 	items    map[string]*item
-	CASToken uint64
+	casToken uint64
 	port     uint16
 	clock    clock.Clock
 }
@@ -58,7 +58,7 @@ type Option func(m *MiniMemcached)
 func newMiniMemcached(opts ...Option) *MiniMemcached {
 	m := MiniMemcached{
 		items:    map[string]*item{},
-		CASToken: 0,
+		casToken: 0,
 		clock:    clock.New(),
 	}
 

--- a/minimemcached.go
+++ b/minimemcached.go
@@ -20,7 +20,7 @@ const (
 type MiniMemcached struct {
 	*server
 	mu       sync.RWMutex
-	items    map[string]*Item
+	items    map[string]*item
 	CASToken uint64
 	port     uint16
 	clock    clock.Clock
@@ -34,8 +34,8 @@ type Config struct {
 	Port uint16
 }
 
-// Item is an object stored in mini-memcached.
-type Item struct {
+// item is an object stored in mini-memcached.
+type item struct {
 	// Value is the actual data stored in the item.
 	Value []byte
 	// Flags is a 32-bit unsigned integer that mini-memcached stores with the data
@@ -57,7 +57,7 @@ type Option func(m *MiniMemcached)
 // newMiniMemcached returns a newMiniMemcached, non-started, MiniMemcached object.
 func newMiniMemcached(opts ...Option) *MiniMemcached {
 	m := MiniMemcached{
-		items:    map[string]*Item{},
+		items:    map[string]*item{},
 		CASToken: 0,
 		clock:    clock.New(),
 	}
@@ -69,7 +69,7 @@ func newMiniMemcached(opts ...Option) *MiniMemcached {
 	return &m
 }
 
-// WithClock applies custom Clock interface. Clock will be used when Item is created
+// WithClock applies custom Clock interface. Clock will be used when item is created.
 func WithClock(clk clock.Clock) Option {
 	return func(m *MiniMemcached) {
 		m.clock = clk

--- a/minimemcached.go
+++ b/minimemcached.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	Version = "1.0.1"
+	Version = "1.1.0"
 )
 
 type MiniMemcached struct {

--- a/minimemcached.go
+++ b/minimemcached.go
@@ -36,19 +36,19 @@ type Config struct {
 
 // item is an object stored in mini-memcached.
 type item struct {
-	// Value is the actual data stored in the item.
-	Value []byte
-	// Flags is a 32-bit unsigned integer that mini-memcached stores with the data
+	// value is the actual data stored in the item.
+	value []byte
+	// flags is a 32-bit unsigned integer that mini-memcached stores with the data
 	// provided by the user.
-	Flags uint32
-	// Expiration is the expiration time in seconds.
-	// 0 means no delay. IF Expiration is more than 30 days, mini-memcached
+	flags uint32
+	// expiration is the expiration time in seconds.
+	// 0 means no delay. IF expiration is more than 30 days, mini-memcached
 	// uses it as a UNIX timestamp for expiration.
-	Expiration int32
-	// CASToken is a unique unsigned 64-bit value of an existing item.
-	CASToken uint64
+	expiration int32
+	// casToken is a unique unsigned 64-bit value of an existing item.
+	casToken uint64
 	// createdAt is UNIX timestamp of the time when item has been created.
-	// It is used for invalidations along with Expiration.
+	// It is used for invalidations along with expiration.
 	createdAt int64
 }
 
@@ -225,17 +225,17 @@ func (m *MiniMemcached) invalidate(key string) {
 	if item == nil {
 		return
 	}
-	if item.Expiration == 0 {
+	if item.expiration == 0 {
 		return
 	}
-	if item.Expiration > ttlUnixTimestamp {
-		if currentTimestamp > int64(item.Expiration) {
+	if item.expiration > ttlUnixTimestamp {
+		if currentTimestamp > int64(item.expiration) {
 			delete(m.items, key)
 			return
 		}
 		return
 	}
-	if currentTimestamp-item.createdAt >= int64(item.Expiration) {
+	if currentTimestamp-item.createdAt >= int64(item.expiration) {
 		delete(m.items, key)
 		return
 	}

--- a/minimemcached.go
+++ b/minimemcached.go
@@ -18,7 +18,7 @@ const (
 )
 
 type MiniMemcached struct {
-	server   *Server
+	*server
 	mu       sync.RWMutex
 	items    map[string]*Item
 	CASToken uint64
@@ -87,7 +87,7 @@ func Run(cfg *Config, opts ...Option) (*MiniMemcached, error) {
 func (m *MiniMemcached) Close() {
 	m.mu.Lock()
 	m.items = nil
-	m.server.close()
+	m.close()
 	m.mu.Unlock()
 	log.Info().Msg("closed mini-memcached.")
 }
@@ -122,7 +122,7 @@ func (m *MiniMemcached) newServer() {
 
 func (m *MiniMemcached) serve() {
 	for {
-		conn, err := m.server.l.Accept()
+		conn, err := m.l.Accept()
 		if err != nil {
 			return
 		}

--- a/minimemcached_test.go
+++ b/minimemcached_test.go
@@ -242,8 +242,8 @@ func TestCASToken(t *testing.T) {
 		t.Error("i1 nil")
 		return
 	}
-	if i1.CASToken != 1 {
-		t.Errorf("i1.CASToken wrong. want: 1, got: %d", i1.CASToken)
+	if i1.casToken != 1 {
+		t.Errorf("i1.casToken wrong. want: 1, got: %d", i1.casToken)
 		return
 	}
 
@@ -252,8 +252,8 @@ func TestCASToken(t *testing.T) {
 		t.Error("i2 nil")
 		return
 	}
-	if i2.CASToken != 2 {
-		t.Errorf("i2.CASToken wrong. want: 2, got: %d", i2.CASToken)
+	if i2.casToken != 2 {
+		t.Errorf("i2.casToken wrong. want: 2, got: %d", i2.casToken)
 		return
 	}
 
@@ -267,8 +267,8 @@ func TestCASToken(t *testing.T) {
 		t.Error("i1 nil")
 		return
 	}
-	if i1.CASToken != 3 {
-		t.Errorf("i1.CASToken wrong. want: 3, got: %d", i1.CASToken)
+	if i1.casToken != 3 {
+		t.Errorf("i1.casToken wrong. want: 3, got: %d", i1.casToken)
 		return
 	}
 
@@ -282,8 +282,8 @@ func TestCASToken(t *testing.T) {
 		t.Error("i3 nil")
 		return
 	}
-	if i3.CASToken != 4 {
-		t.Errorf("i3.CASToken wrong. want: 4, got: %d", i3.CASToken)
+	if i3.casToken != 4 {
+		t.Errorf("i3.casToken wrong. want: 4, got: %d", i3.casToken)
 		return
 	}
 
@@ -292,8 +292,8 @@ func TestCASToken(t *testing.T) {
 		t.Error("i2 nil")
 		return
 	}
-	if i2.CASToken != 2 {
-		t.Errorf("i2.CASToken wrong. want: 2, got: %d", i2.CASToken)
+	if i2.casToken != 2 {
+		t.Errorf("i2.casToken wrong. want: 2, got: %d", i2.casToken)
 		return
 	}
 }

--- a/minimemcached_test.go
+++ b/minimemcached_test.go
@@ -486,7 +486,7 @@ func writeAppend(port uint16, key string, value []byte) error {
 		return err
 	}
 
-	message := fmt.Sprintf("%s %s %d %d %d", APPEND, key, 0, 0, len(value))
+	message := fmt.Sprintf("%s %s %d %d %d", appendCmd, key, 0, 0, len(value))
 
 	if _, err := conn.Write(append([]byte(message), crlf...)); err != nil {
 		return err
@@ -513,7 +513,7 @@ func writePrepend(port uint16, key string, value []byte) error {
 		return err
 	}
 
-	message := fmt.Sprintf("%s %s %d %d %d", PREPEND, key, 0, 0, len(value))
+	message := fmt.Sprintf("%s %s %d %d %d", prependCmd, key, 0, 0, len(value))
 
 	if _, err := conn.Write(append([]byte(message), crlf...)); err != nil {
 		return err

--- a/server.go
+++ b/server.go
@@ -6,22 +6,22 @@ import (
 	"net"
 )
 
-type Server struct {
+type server struct {
 	l net.Listener
 }
 
 // NewServer starts and returns a server listening on a given port.
-func newServer(port uint16) (*Server, error) {
+func newServer(port uint16) (*server, error) {
 	l, err := net.Listen("tcp", fmt.Sprintf(":%d", port))
 	if err != nil {
 		log.Printf("failed to listen on port: %d", port)
 		return nil, err
 	}
-	return &Server{l: l}, nil
+	return &server{l: l}, nil
 }
 
 // Close closes a server started with NewServer().
-func (s *Server) close() {
+func (s *server) close() {
 	if s.l != nil {
 		_ = s.l.Close()
 		s.l = nil

--- a/server.go
+++ b/server.go
@@ -10,7 +10,7 @@ type server struct {
 	l net.Listener
 }
 
-// NewServer starts and returns a server listening on a given port.
+// newServer starts and returns a server listening on a given port.
 func newServer(port uint16) (*server, error) {
 	l, err := net.Listen("tcp", fmt.Sprintf(":%d", port))
 	if err != nil {
@@ -20,7 +20,7 @@ func newServer(port uint16) (*server, error) {
 	return &server{l: l}, nil
 }
 
-// Close closes a server started with NewServer().
+// close closes server started with NewServer().
 func (s *server) close() {
 	if s.l != nil {
 		_ = s.l.Close()


### PR DESCRIPTION
* `Server` struct is not used on clients, so I unexported it.
* While unexporting, I figured out it could also exist as an embedded attribute of `Minimemcached` struct.   
  If you think this decreases readability, please leave a review comment about it.
