### PR TITLE
refactor: Make function for increment of casToken

### DIFF
--- a/minimemcached.go
+++ b/minimemcached.go
@@ -240,3 +240,9 @@ func (m *MiniMemcached) invalidate(key string) {
 		return
 	}
 }
+
+// incrementCASToken() increments the CAS token.
+func (m *MiniMemcached) incrementCASToken() uint64 {
+	m.casToken++
+	return m.casToken
+}


### PR DESCRIPTION
- Codes such as `m.casToken += 1` and `item.casToken = m.casToken` was being executed in almost every   
  command handling functions, so I decided to make a function for it.
