### PR TITLE
refactor(test): Use TestMain() for starting MiniMemcached

### DIFF
--- a/minimemcached_test.go
+++ b/minimemcached_test.go
@@ -16,13 +16,13 @@ import (
 	"github.com/bradfitz/gomemcache/memcache"
 )
 
-var cfg = &Config{
-	Port: 0,
-}
-var port uint16
-var clk = clock.NewMock()
-var mc *memcache.Client
-var mm *MiniMemcached
+var (
+	cfg  = &Config{Port: 0}
+	port uint16
+	clk  = clock.NewMock()
+	mc   *memcache.Client
+	mm   *MiniMemcached
+)
 
 func TestMain(m *testing.M) {
 	var err error


### PR DESCRIPTION
### Use `TestMain()` in test codes

- In previous test code, `MiniMemcached` was being started in each test case.   
  This resulted in same codes to be written in every each test case, so I refactored   
  it to only start `MiniMemcached` once in `TestMain()`.

- `removeAllPreviousData()` calls `flush_all` to `MiniMemcached`, which clears all   
  stored caches, and also sets casToken's value to 0.

