### PR TITLE
chore: change to listen to locahost only

### DIFF
--- a/server.go
+++ b/server.go
@@ -12,7 +12,7 @@ type server struct {
 
 // newServer starts and returns a server listening on a given port.
 func newServer(port uint16) (*server, error) {
-	l, err := net.Listen("tcp", fmt.Sprintf(":%d", port))
+	l, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", port))
 	if err != nil {
 		log.Printf("failed to listen on port: %d", port)
 		return nil, err

--- a/server.go
+++ b/server.go
@@ -12,7 +12,7 @@ type server struct {
 
 // newServer starts and returns a server listening on a given port.
 func newServer(port uint16) (*server, error) {
-	l, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", port))
+	l, err := net.Listen("tcp", fmt.Sprintf("localhost:%d", port))
 	if err != nil {
 		log.Printf("failed to listen on port: %d", port)
 		return nil, err


### PR DESCRIPTION
server port listen시 외부까지 port가 오픈되어 실행되고 있어요.
이로 실행시마다 방화벽 알람이 발생해요.
가능성은 굉장히 낮지만 보안취약점 발생 위험이 있고요.